### PR TITLE
use require-dev instead for phpunit and coveralls

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,9 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.4.0"
+    },
+    "require-dev": {
         "phpunit/phpunit": "4.*",
         "satooshi/php-coveralls": "0.*@dev"
     },

--- a/src/BusinessDays/Calculator.php
+++ b/src/BusinessDays/Calculator.php
@@ -170,7 +170,7 @@ class Calculator
      *
      * @return bool
      */
-    private function isFreeWeekDayDay(\DateTime $date)
+    public function isFreeWeekDayDay(\DateTime $date)
     {
         $currentWeekDay = (int)$date->format(self::WEEK_DAY_FORMAT);
 
@@ -186,7 +186,7 @@ class Calculator
      *
      * @return bool
      */
-    private function isHoliday(\DateTime $date)
+    public function isHoliday(\DateTime $date)
     {
         $holidayFormatValue = $date->format(self::HOLIDAY_FORMAT);
         foreach ($this->getHolidays() as $holiday) {
@@ -203,7 +203,7 @@ class Calculator
      *
      * @return bool
      */
-    private function isFreeDay(\DateTime $date)
+    public function isFreeDay(\DateTime $date)
     {
         $freeDayFormatValue = $date->format(self::FREE_DAY_FORMAT);
         foreach ($this->getFreeDays() as $freeDay) {


### PR DESCRIPTION
Some people cannot use phpunit 4. I have to use 3, making that a requirement doesn't make sense since it really isn't a requirement.