### PR TITLE
Upgrade dependency of php-coveralls

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "4.*",
-        "satooshi/php-coveralls": "0.*@dev"
+        "satooshi/php-coveralls": "~1.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
In fact, why is it required? The tree requires an old version of Guzzle, which shows up as a warning.